### PR TITLE
Mention Yandex as an available alternative translator

### DIFF
--- a/guides/configure-httplug.rst
+++ b/guides/configure-httplug.rst
@@ -58,7 +58,7 @@ and a PSR-6 cache pool.
         # ...
         http_client: 'httplug.client.translator_client'
         fallback_translation:
-            service: 'google'
+            service: 'google' # 'yandex' is available as an alternative
             api_key: 'foobar'
 
 .. note::

--- a/overview.rst
+++ b/overview.rst
@@ -53,7 +53,7 @@ Translator
    :alt: Total Downloads
 
 The translator package includes third party translation clients. Use this package
-if you want to translate a string with Google Translate or Bing Translate.
+if you want to translate a string with Google Translate, Yandex Translate or Bing Translate.
 Read more :doc:`about translators <components/translator>`.
 
 Storage adapters


### PR DESCRIPTION
Just applied this patch: https://github.com/php-translation/symfony-bundle/pull/151 and it works well for me.

But we need to merge it only after https://github.com/php-translation/symfony-bundle/pull/151 is merged