### PR TITLE
Add missing 'enabled' option to the configuration example

### DIFF
--- a/symfony/auto-add-missing.rst
+++ b/symfony/auto-add-missing.rst
@@ -14,6 +14,7 @@ Configuration
     translation:
       # ..
       auto_add_missing_translations:
+        enabled: true
         config_name: 'default'
       # ..
 


### PR DESCRIPTION
The `bin/console conf:dump translation` command shows the default config as:
```yaml
translation:
    # ...
    auto_add_missing_translations:
        enabled:              false
        config_name:          default
```